### PR TITLE
Add Context Bundler VS Code extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+out

--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,10 @@
-VS code extension that helps you copy and paste your codebase into an LLM’s context. 
+# Context Bundler
+
+VS Code extension to bundle files for large language models. Select files in the sidebar and copy them to your clipboard as a single text block.
+
+## Development
+
+```
+npm install
+npm run compile
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,70 @@
+{
+  "name": "context-bundler",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "context-bundler",
+      "version": "0.0.1",
+      "dependencies": {
+        "ignore": "^5.3.1"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.19",
+        "@types/vscode": "^1.85.0",
+        "typescript": "^5.2.2"
+      },
+      "engines": {
+        "vscode": "^1.85.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.4.tgz",
+      "integrity": "sha512-OP+We5WV8Xnbuvw0zC2m4qfB/BJvjyCwtNjhHdJxV1639SGSKrLmJkc3fMnp2Qy8nJyHp8RO6umxELN/dS1/EA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.101.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.101.0.tgz",
+      "integrity": "sha512-ZWf0IWa+NGegdW3iU42AcDTFHWW7fApLdkdnBqwYEtHVIBGbTu0ZNQKP/kX3Ds/uMJXIMQNAojHR4vexCEEz5Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "context-bundler",
+  "displayName": "Context Bundler",
+  "description": "Easily bundle files for LLM context windows.",
+  "version": "0.0.1",
+  "publisher": "codex",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": ["Other"],
+  "activationEvents": ["*"],
+  "main": "./out/extension.js",
+  "contributes": {
+    "views": {
+      "explorer": [
+        {
+          "id": "contextBundlerView",
+          "name": "Context Bundler",
+          "type": "tree"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "context-bundler.copyToClipboard",
+        "title": "Copy Selected Files to Clipboard",
+        "icon": "$(clippy)"
+      },
+      {
+        "command": "context-bundler.toggleNode",
+        "title": "Toggle Node"
+      }
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "context-bundler.copyToClipboard",
+          "when": "view == contextBundlerView",
+          "group": "navigation"
+        }
+      ]
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.19",
+    "@types/vscode": "^1.85.0",
+    "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "ignore": "^5.3.1"
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,48 @@
+import * as vscode from 'vscode';
+import { ContextTreeProvider } from './tree/ContextTreeProvider';
+import { ClipboardHandler } from './utils/ClipboardHandler';
+
+export function activate(context: vscode.ExtensionContext) {
+    console.log('Extension "context-bundler" is now active!');
+
+    const rootPath = vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0
+        ? vscode.workspace.workspaceFolders[0].uri.fsPath
+        : undefined;
+
+    const treeProvider = new ContextTreeProvider(rootPath);
+    const treeView = vscode.window.createTreeView('contextBundlerView', {
+        treeDataProvider: treeProvider
+    });
+    treeProvider.onSelectionChange(total => {
+        treeView.description = `~${total} tokens selected`;
+    });
+
+    const toggleCmd = vscode.commands.registerCommand('context-bundler.toggleNode', (node: any) => {
+        treeProvider.toggleNode(node);
+    });
+
+    const clipboardHandler = rootPath ? new ClipboardHandler(rootPath) : undefined;
+
+    const copyCmd = vscode.commands.registerCommand('context-bundler.copyToClipboard', () => {
+        if (!clipboardHandler) {
+            vscode.window.showWarningMessage('No workspace opened.');
+            return;
+        }
+        const selected = treeProvider.getSelectedNodes();
+        if (selected.length === 0) {
+            vscode.window.showWarningMessage('No files selected.');
+            return;
+        }
+        clipboardHandler.bundleAndCopyToClipboard(selected);
+    });
+
+    const watcher = rootPath ? vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(rootPath, '**/*')) : undefined;
+    watcher?.onDidCreate(() => treeProvider.refresh());
+    watcher?.onDidDelete(() => treeProvider.refresh());
+    watcher?.onDidChange(() => treeProvider.refresh());
+
+    if (watcher) context.subscriptions.push(watcher);
+    context.subscriptions.push(copyCmd, toggleCmd, treeView);
+}
+
+export function deactivate() {}

--- a/src/tree/ContextNode.ts
+++ b/src/tree/ContextNode.ts
@@ -1,0 +1,18 @@
+import * as vscode from 'vscode';
+
+export type SelectionState = 'checked' | 'unchecked' | 'indeterminate';
+
+export class ContextNode extends vscode.TreeItem {
+    public children: ContextNode[] = [];
+    public selectionState: SelectionState = 'unchecked';
+    public tokenCount = 0;
+
+    constructor(
+        public readonly resourceUri: vscode.Uri,
+        public readonly label: string,
+        public readonly fileType: vscode.FileType
+    ) {
+        super(label, fileType === vscode.FileType.Directory ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None);
+        this.id = resourceUri.fsPath;
+    }
+}

--- a/src/tree/ContextTreeProvider.ts
+++ b/src/tree/ContextTreeProvider.ts
@@ -1,0 +1,159 @@
+import * as vscode from 'vscode';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { ContextNode, SelectionState } from './ContextNode';
+import { IgnoreManager } from '../utils/IgnoreManager';
+import { TokenEstimator } from '../utils/TokenEstimator';
+
+export class ContextTreeProvider implements vscode.TreeDataProvider<ContextNode> {
+    private _onDidChangeTreeData: vscode.EventEmitter<ContextNode | undefined | void> = new vscode.EventEmitter();
+    readonly onDidChangeTreeData: vscode.Event<ContextNode | undefined | void> = this._onDidChangeTreeData.event;
+
+    private _onSelectionChange: vscode.EventEmitter<number> = new vscode.EventEmitter();
+    readonly onSelectionChange: vscode.Event<number> = this._onSelectionChange.event;
+
+    private allNodes: Map<string, ContextNode> = new Map();
+    private ignoreManager?: IgnoreManager;
+    private estimator = new TokenEstimator();
+
+    constructor(private workspaceRoot: string | undefined) {
+        if (workspaceRoot) {
+            this.ignoreManager = new IgnoreManager(workspaceRoot);
+            this.ignoreManager.loadRules();
+        }
+    }
+
+    refresh(): void {
+        this.allNodes.clear();
+        this._onDidChangeTreeData.fire();
+    }
+
+    getTreeItem(element: ContextNode): vscode.TreeItem {
+        switch (element.selectionState) {
+            case 'checked':
+                element.iconPath = new vscode.ThemeIcon('check');
+                break;
+            case 'indeterminate':
+                element.iconPath = new vscode.ThemeIcon('pass');
+                break;
+            default:
+                element.iconPath = new vscode.ThemeIcon('circle-large-outline');
+        }
+        if (element.tokenCount) {
+            element.description = `${element.tokenCount}t`;
+        }
+        element.command = {
+            command: 'context-bundler.toggleNode',
+            title: 'Toggle',
+            arguments: [element]
+        };
+        return element;
+    }
+
+    async getChildren(element?: ContextNode): Promise<ContextNode[]> {
+        if (!this.workspaceRoot) {
+            vscode.window.showInformationMessage('No folder or workspace opened');
+            return [];
+        }
+
+        if (!element) {
+            const rootUri = vscode.Uri.file(this.workspaceRoot);
+            const rootStat = await vscode.workspace.fs.stat(rootUri);
+            const rootNode = await this.createNode(rootUri, rootStat);
+            return [rootNode];
+        }
+
+        if (element.fileType === vscode.FileType.Directory) {
+            return this.getDirectoryChildren(element);
+        }
+        return [];
+    }
+
+    private async getDirectoryChildren(parent: ContextNode): Promise<ContextNode[]> {
+        const entries = await vscode.workspace.fs.readDirectory(parent.resourceUri);
+        const nodes: ContextNode[] = [];
+        for (const [name, type] of entries) {
+            const uri = vscode.Uri.joinPath(parent.resourceUri, name);
+            if (this.ignoreManager && this.ignoreManager.isIgnored(uri.fsPath)) {
+                continue;
+            }
+            const node = await this.createNode(uri, type);
+            parent.children.push(node);
+            nodes.push(node);
+        }
+        return nodes;
+    }
+
+    private async createNode(uri: vscode.Uri, fileTypeOrStat: vscode.FileType | vscode.FileStat): Promise<ContextNode> {
+        const fileType = (fileTypeOrStat as vscode.FileStat).type !== undefined ? (fileTypeOrStat as vscode.FileStat).type : fileTypeOrStat as vscode.FileType;
+        const label = path.basename(uri.fsPath);
+        const node = new ContextNode(uri, label, fileType);
+        this.allNodes.set(uri.fsPath, node);
+
+        if (fileType === vscode.FileType.File) {
+            try {
+                const content = await fs.readFile(uri.fsPath, 'utf-8');
+                node.tokenCount = this.estimator.estimateTokens(content);
+            } catch {
+                node.tokenCount = 0;
+            }
+        }
+        return node;
+    }
+
+    toggleNode(node: ContextNode): void {
+        const newState: SelectionState = node.selectionState === 'checked' ? 'unchecked' : 'checked';
+        this.setNodeState(node, newState);
+        this._onDidChangeTreeData.fire(node);
+        this.propagateStateUp(node);
+        this.emitSelectionTokens();
+    }
+
+    private setNodeState(node: ContextNode, state: SelectionState): void {
+        node.selectionState = state;
+        if (state !== 'indeterminate' && node.fileType === vscode.FileType.Directory) {
+            node.children.forEach(child => this.setNodeState(child, state));
+        }
+    }
+
+    private propagateStateUp(node: ContextNode): void {
+        const parent = this.findParent(node);
+        if (!parent) { return; }
+        const childStates = parent.children.map(c => c.selectionState);
+        const allChecked = childStates.every(s => s === 'checked');
+        const allUnchecked = childStates.every(s => s === 'unchecked');
+        if (allChecked) {
+            parent.selectionState = 'checked';
+        } else if (allUnchecked) {
+            parent.selectionState = 'unchecked';
+        } else {
+            parent.selectionState = 'indeterminate';
+        }
+        this._onDidChangeTreeData.fire(parent);
+        this.propagateStateUp(parent);
+    }
+
+    private emitSelectionTokens(): void {
+        const total = this.getSelectedNodes().reduce((sum, n) => sum + n.tokenCount, 0);
+        this._onSelectionChange.fire(total);
+    }
+
+    private findParent(child: ContextNode): ContextNode | undefined {
+        for (const node of this.allNodes.values()) {
+            if (node.children.includes(child)) {
+                return node;
+            }
+        }
+        return undefined;
+    }
+
+    getSelectedNodes(): ContextNode[] {
+        const nodes: ContextNode[] = [];
+        for (const node of this.allNodes.values()) {
+            if (node.selectionState === 'checked' && node.fileType === vscode.FileType.File) {
+                nodes.push(node);
+            }
+        }
+        return nodes;
+    }
+}

--- a/src/utils/ClipboardHandler.ts
+++ b/src/utils/ClipboardHandler.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { ContextNode } from '../tree/ContextNode';
+
+export class ClipboardHandler {
+    constructor(private workspaceRoot: string) {}
+
+    async bundleAndCopyToClipboard(selectedNodes: ContextNode[]): Promise<void> {
+        let bundled = '';
+        for (const node of selectedNodes) {
+            const relative = path.relative(this.workspaceRoot, node.resourceUri.fsPath);
+            const content = await fs.readFile(node.resourceUri.fsPath, 'utf-8');
+            bundled += `// ${relative}\n\n${content}\n\n`;
+        }
+        await vscode.env.clipboard.writeText(bundled);
+        vscode.window.showInformationMessage(`Copied ${selectedNodes.length} files to clipboard!`);
+    }
+}

--- a/src/utils/IgnoreManager.ts
+++ b/src/utils/IgnoreManager.ts
@@ -1,0 +1,26 @@
+import * as vscode from 'vscode';
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import ignore from 'ignore';
+
+export class IgnoreManager {
+    private ig = ignore();
+
+    constructor(private workspaceRoot: string) {}
+
+    async loadRules() {
+        this.ig.add('.git');
+        try {
+            const gitignorePath = path.join(this.workspaceRoot, '.gitignore');
+            const content = await fs.readFile(gitignorePath, 'utf-8');
+            this.ig.add(content);
+        } catch {
+            // ignore
+        }
+    }
+
+    isIgnored(filePath: string): boolean {
+        const relativePath = path.relative(this.workspaceRoot, filePath);
+        return this.ig.ignores(relativePath);
+    }
+}

--- a/src/utils/TokenEstimator.ts
+++ b/src/utils/TokenEstimator.ts
@@ -1,0 +1,5 @@
+export class TokenEstimator {
+    estimateTokens(content: string): number {
+        return Math.ceil(content.length / 4);
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "out",
+    "rootDir": "src",
+    "lib": ["es2020"],
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
## Summary
- scaffold a VS Code extension in TypeScript
- implement tree view with selectable nodes
- add clipboard bundling and token estimation utilities
- track selection token totals in the sidebar

## Testing
- `npm install`
- `npm run compile`

------
https://chatgpt.com/codex/tasks/task_e_6867fabc863c832984a8a8d4450a0ae3