### PR TITLE
Improve ignore handling and selection persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@types/node": "^20.11.19",
     "@types/vscode": "^1.85.0",
+    "@types/ignore": "^5.2.2",
     "typescript": "^5.2.2"
   },
   "dependencies": {

--- a/src/utils/IgnoreManager.ts
+++ b/src/utils/IgnoreManager.ts
@@ -1,18 +1,26 @@
-import * as vscode from 'vscode';
-import { promises as fs } from 'fs';
+import * as fs from 'fs';
 import * as path from 'path';
 import ignore from 'ignore';
 
 export class IgnoreManager {
     private ig = ignore();
 
-    constructor(private workspaceRoot: string) {}
+    constructor(private workspaceRoot: string) {
+        this.loadRulesSync();
+    }
 
-    async loadRules() {
+    private loadRulesSync() {
         this.ig.add('.git');
         try {
             const gitignorePath = path.join(this.workspaceRoot, '.gitignore');
-            const content = await fs.readFile(gitignorePath, 'utf-8');
+            const content = fs.readFileSync(gitignorePath, 'utf-8');
+            this.ig.add(content);
+        } catch {
+            // ignore
+        }
+        try {
+            const contextignorePath = path.join(this.workspaceRoot, '.contextignore');
+            const content = fs.readFileSync(contextignorePath, 'utf-8');
             this.ig.add(content);
         } catch {
             // ignore


### PR DESCRIPTION
## Summary
- load `.gitignore` and `.contextignore` synchronously on startup
- persist selection state across refreshes
- set better icon for indeterminate state
- propagate selection to new children and after refresh
- add `@types/ignore` to dev dependencies

## Testing
- `npm install` *(fails: 404 Not Found)*
- `npm run compile`


------
https://chatgpt.com/codex/tasks/task_e_6867ff2be5f08329bc04ce6164b86477