### PR TITLE
Implement ignore reload and directory token counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,9 @@ Context Bundler is a simple VS Code extension for packaging selected files into 
 4. Click the clipboard icon or run the `Context Bundler: Copy Selected Files to Clipboard` command.
 5. Paste the result into your LLM conversation.
 
-The extension respects `.gitignore` rules automatically and only reads files inside your workspace.
+The extension respects `.gitignore` rules automatically and also loads patterns from an optional `.contextignore` file at the workspace root. Use `.contextignore` to exclude files that are not tracked by git but should still be ignored by the bundler.
+
+## TODO
+
+- Use an actual tokenizer for more accurate token counts.
+- Add unit tests for the utility classes.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,9 +37,24 @@ export function activate(context: vscode.ExtensionContext) {
     });
 
     const watcher = rootPath ? vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(rootPath, '**/*')) : undefined;
-    watcher?.onDidCreate(() => treeProvider.refresh());
-    watcher?.onDidDelete(() => treeProvider.refresh());
-    watcher?.onDidChange(() => treeProvider.refresh());
+    watcher?.onDidCreate(uri => {
+        if (uri.path.endsWith('.gitignore') || uri.path.endsWith('.contextignore')) {
+            treeProvider.reloadIgnoreRules();
+        }
+        treeProvider.onFileChange(uri);
+    });
+    watcher?.onDidDelete(uri => {
+        if (uri.path.endsWith('.gitignore') || uri.path.endsWith('.contextignore')) {
+            treeProvider.reloadIgnoreRules();
+        }
+        treeProvider.onFileDelete(uri);
+    });
+    watcher?.onDidChange(uri => {
+        if (uri.path.endsWith('.gitignore') || uri.path.endsWith('.contextignore')) {
+            treeProvider.reloadIgnoreRules();
+        }
+        treeProvider.onFileChange(uri);
+    });
 
     if (watcher) context.subscriptions.push(watcher);
     context.subscriptions.push(copyCmd, toggleCmd, treeView);

--- a/src/test/suite/ignore.test.ts
+++ b/src/test/suite/ignore.test.ts
@@ -1,0 +1,26 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { IgnoreManager } from '../../utils/IgnoreManager';
+
+describe('IgnoreManager', () => {
+  it('loads patterns from .contextignore', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-'));
+    fs.writeFileSync(path.join(tmp, '.contextignore'), 'foo.txt');
+    fs.writeFileSync(path.join(tmp, 'foo.txt'), '');
+    const mgr = new IgnoreManager(tmp);
+    assert.strictEqual(mgr.isIgnored(path.join(tmp, 'foo.txt')), true);
+  });
+
+  it('reloadRules picks up file changes', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-'));
+    fs.writeFileSync(path.join(tmp, '.gitignore'), '');
+    fs.writeFileSync(path.join(tmp, 'bar.txt'), '');
+    const mgr = new IgnoreManager(tmp);
+    assert.strictEqual(mgr.isIgnored(path.join(tmp, 'bar.txt')), false);
+    fs.writeFileSync(path.join(tmp, '.gitignore'), 'bar.txt');
+    mgr.reloadRules();
+    assert.strictEqual(mgr.isIgnored(path.join(tmp, 'bar.txt')), true);
+  });
+});

--- a/src/test/suite/provider.test.ts
+++ b/src/test/suite/provider.test.ts
@@ -1,0 +1,25 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { ContextTreeProvider } from '../../tree/ContextTreeProvider';
+import { TokenEstimator } from '../../utils/TokenEstimator';
+
+suite('ContextTreeProvider', () => {
+  test('directory token counts sum children', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cb-'));
+    const sub = path.join(tmp, 'sub');
+    fs.mkdirSync(sub);
+    fs.writeFileSync(path.join(sub, 'a.txt'), 'aaaa');
+    fs.writeFileSync(path.join(sub, 'b.txt'), 'bbbb');
+
+    const provider = new ContextTreeProvider(tmp);
+    const [root] = await provider.getChildren();
+    const [subDir] = await provider.getChildren(root);
+
+    const estimator = new TokenEstimator();
+    const expected = estimator.estimateTokens('aaaa') + estimator.estimateTokens('bbbb');
+    assert.strictEqual(subDir.tokenCount, expected);
+    assert.strictEqual(root.tokenCount, expected);
+  });
+});

--- a/src/utils/IgnoreManager.ts
+++ b/src/utils/IgnoreManager.ts
@@ -27,6 +27,11 @@ export class IgnoreManager {
         }
     }
 
+    reloadRules() {
+        this.ig = ignore();
+        this.loadRulesSync();
+    }
+
     isIgnored(filePath: string): boolean {
         const relativePath = path.relative(this.workspaceRoot, filePath);
         return this.ig.ignores(relativePath);


### PR DESCRIPTION
## Summary
- document `.contextignore` and add TODO list
- add reloadRules() to `IgnoreManager`
- keep token cache and ignore reload helpers in `ContextTreeProvider`
- watch ignore files and changed files in the extension
- provide new tests for ignore manager and tree provider

## Testing
- `npm run compile` *(fails: Cannot find module 'vscode')*
- `npm test` *(fails: Cannot find module '@vscode/test-electron')*

------
https://chatgpt.com/codex/tasks/task_e_6869dd61bbb48329ae41febef80b3800